### PR TITLE
Fix health check. (bypass caching mechanism of ArangoTemplate)

### DIFF
--- a/arangodb-spring-boot-autoconfigure/src/main/java/io/github/ganchix/arangodb/health/ArangoHealthCheck.java
+++ b/arangodb-spring-boot-autoconfigure/src/main/java/io/github/ganchix/arangodb/health/ArangoHealthCheck.java
@@ -32,7 +32,7 @@ public class ArangoHealthCheck extends AbstractHealthIndicator {
         boolean exists = arangoOperations.driver().db().exists();
         builder.withDetail("exists", exists);
         if (exists) {
-            ArangoDBVersion version = arangoOperations.getVersion();
+            ArangoDBVersion version = arangoOperations.driver().getVersion();
             builder.up();
             builder.withDetail("server", version.getServer());
             builder.withDetail("version", version.getVersion());


### PR DESCRIPTION
`ArangoTemplate` (the implementation of `ArangoOperations`) is caching the version, so it's not useful to use this for health checking. The PR change this to use the driver API directly.